### PR TITLE
Feat/volunteer notifications cu 865btm848

### DIFF
--- a/source/php/App.php
+++ b/source/php/App.php
@@ -30,7 +30,7 @@ class App
         new Api();
 
         //Post types
-        $assignment = new Assignment($notificationsHandler);
+        $assignment = new Assignment();
         $assignment->addHooks();
 
         $employee = new Employee();

--- a/source/php/Employee.php
+++ b/source/php/Employee.php
@@ -21,6 +21,20 @@ class Employee
     public function addHooks()
     {
         add_action('init', array($this, 'insertEmploymentStatusTerms'));
+        add_filter('avm_external_volunteer_new_notification', array($this, 'populateNotificationWithReceiver'), 10, 2);
+    }
+
+    /**
+     * Populate notification with receiver email address
+     * @param array $args
+     * @param int   $postId
+     * @return array
+     */
+    public function populateNotificationWithReceiver(array $args, int $postId): array
+    {
+        $receiver = get_field('email', $postId);
+        $args['to'] = $receiver ?? '';
+        return $args;
     }
 
     /**

--- a/source/php/Notification/NotificationHandler.php
+++ b/source/php/Notification/NotificationHandler.php
@@ -87,7 +87,7 @@ class NotificationHandler implements NotificationHandlerInterface
         $taxonomyNotifications = $this->getNotificationsByTaxonomy($this->config, $taxonomy);
         $matchingEvents = $this->findMatchingEvents($taxonomyNotifications, $oldAndNewValues);
         foreach ($matchingEvents as $event) {
-            if ($this->shouldScheduleNotification($postId, $event['rule'], 'get_field')) {
+            if ($this->shouldScheduleNotification($postId, $event['rule'] ?? [], 'get_field')) {
                 $this->scheduleNotificationCronEvent($event, $postId);
             }
         }

--- a/source/php/Notification/NotificationHandlerInterface.php
+++ b/source/php/Notification/NotificationHandlerInterface.php
@@ -10,7 +10,7 @@ interface NotificationHandlerInterface
 
     public function scheduleNotificationCronEvent(array $notification, int $postId): void;
 
-    public function scheduleNotificationsForTermUpdates(array $newTermIds, array $oldTermIds, string $postType, string $taxonomy, int $postId): void;
+    public function scheduleNotificationsForTermUpdates(array $newTermIds, array $oldTermIds, string $taxonomy, int $postId): void;
 
     public function shouldScheduleNotification(int $postId, array $rule, callable $getFieldFn): bool;
 
@@ -20,5 +20,5 @@ interface NotificationHandlerInterface
 
     public function convertTermIdsToSlugs(array $termIds, string $taxonomy): array;
 
-    public function getNotifications(string $postType, string $taxonomy): array;
+    public function getNotificationsByTaxonomy(array $notifications, string $taxonomy): array;
 }

--- a/source/php/Notification/NotificationsConfig.php
+++ b/source/php/Notification/NotificationsConfig.php
@@ -5,40 +5,50 @@ namespace VolunteerManager\Notification;
 class NotificationsConfig
 {
     public static array $notifications = [
-        'assignment' => [
-            'assignment-status' => [
-                [
-                    'key' => 'assignment_approved',
-                    'oldValue' => 'pending',
-                    'newValue' => 'approved',
-                    'message' => [
-                        'subject' => 'Assignment approved subject',
-                        'content' => 'Assignment approved message',
-                    ],
-                    'rule' => [
-                        'key' => 'source',
-                        'value' => '',
-                        'operator' => 'NOT_EQUAL'
-                    ]
-                ],
-                [
-                    'key' => 'assignment_denied',
-                    'oldValue' => 'pending',
-                    'newValue' => 'denied',
-                    'message' => [
-                        'subject' => 'Assignment denied subject',
-                        'content' => 'Assignment denied message',
-                    ],
-                    'rule' => [
-                        'key' => 'source',
-                        'value' => '',
-                        'operator' => 'NOT_EQUAL'
-                    ]
-                ]
+        [
+            'key' => 'external_assignment_approved',
+            'taxonomy' => 'assignment-status',
+            'oldValue' => 'pending',
+            'newValue' => 'approved',
+            'message' => [
+                'subject' => 'Assignment approved subject',
+                'content' => 'Assignment approved message',
+            ],
+            'rule' => [
+                'key' => 'source',
+                'value' => '',
+                'operator' => 'NOT_EQUAL'
             ]
         ],
-        'volunteer' => [
-            // add notifications
+        [
+            'key' => 'external_assignment_denied',
+            'taxonomy' => 'assignment-status',
+            'oldValue' => 'pending',
+            'newValue' => 'denied',
+            'message' => [
+                'subject' => 'Assignment denied subject',
+                'content' => 'Assignment denied message',
+            ],
+            'rule' => [
+                'key' => 'source',
+                'value' => '',
+                'operator' => 'NOT_EQUAL'
+            ]
+        ],
+        [
+            'key' => 'external_volunteer_new',
+            'taxonomy' => 'employee-registration-status',
+            'oldValue' => '',
+            'newValue' => 'new',
+            'message' => [
+                'subject' => 'Application received',
+                'content' => 'Your application has been received. More info here...',
+            ],
+            'rule' => [
+                'key' => 'source',
+                'value' => '',
+                'operator' => 'NOT_EQUAL'
+            ]
         ]
     ];
 }

--- a/source/php/Notification/NotificationsConfig.php
+++ b/source/php/Notification/NotificationsConfig.php
@@ -5,7 +5,7 @@ namespace VolunteerManager\Notification;
 class NotificationsConfig
 {
     public static array $notifications = [
-        [
+        "Message to submitter when externally created assignments is approved" => [
             'key' => 'external_assignment_approved',
             'taxonomy' => 'assignment-status',
             'oldValue' => 'pending',
@@ -20,7 +20,7 @@ class NotificationsConfig
                 'operator' => 'NOT_EQUAL'
             ]
         ],
-        [
+        "Message to submitter when externally created assignments is denied" => [
             'key' => 'external_assignment_denied',
             'taxonomy' => 'assignment-status',
             'oldValue' => 'pending',
@@ -35,7 +35,7 @@ class NotificationsConfig
                 'operator' => 'NOT_EQUAL'
             ]
         ],
-        [
+        "Message to volunteer when a new application is created" => [
             'key' => 'external_volunteer_new',
             'taxonomy' => 'employee-registration-status',
             'oldValue' => '',

--- a/source/tests/php/AssignmentTest.php
+++ b/source/tests/php/AssignmentTest.php
@@ -78,7 +78,7 @@ class AssignmentTest extends PluginTestCase
         $this->assertEquals($expectedResult, $this->assignment->populateNotificationWithSubmitter($args, 123));
     }
 
-    public function notificationReceiverProvider()
+    public function notificationReceiverProvider(): array
     {
         return [
             [
@@ -103,7 +103,7 @@ class AssignmentTest extends PluginTestCase
         $this->assertEquals($expectedResult, $this->assignment->populateNotificationSender($args, 1));
     }
 
-    public function notificationSenderProvider()
+    public function notificationSenderProvider(): array
     {
         return [
             [

--- a/source/tests/php/AssignmentTest.php
+++ b/source/tests/php/AssignmentTest.php
@@ -5,7 +5,6 @@ namespace php;
 use Brain\Monkey\Functions;
 use PluginTestCase\PluginTestCase;
 use VolunteerManager\Assignment;
-use VolunteerManager\Notification\NotificationHandler;
 
 class AssignmentTest extends PluginTestCase
 {
@@ -18,12 +17,7 @@ class AssignmentTest extends PluginTestCase
 
         $this->post = new \stdClass();
         $this->post->ID = 123;
-
-        $emailServiceMock = $this->getMockBuilder('VolunteerManager\Notification\EmailNotificationSender')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $notificationHandler = new NotificationHandler([], $emailServiceMock);
-        $this->assignment = new Assignment($notificationHandler);
+        $this->assignment = new Assignment();
     }
 
     public function testRenderSubmitterData(): void
@@ -75,7 +69,7 @@ class AssignmentTest extends PluginTestCase
     public function testPopulateNotificationWithSubmitter($args, $getPostMetaResult, $expectedResult)
     {
         Functions\when('get_post_meta')->justReturn($getPostMetaResult);
-        $this->assertEquals($expectedResult, $this->assignment->populateNotificationWithSubmitter($args, 123));
+        $this->assertEquals($expectedResult, $this->assignment->populateNotificationWithSubmitter($args, $this->post->ID));
     }
 
     public function notificationReceiverProvider(): array
@@ -100,7 +94,7 @@ class AssignmentTest extends PluginTestCase
     public function testPopulateNotificationSenderWithEmail($args, $getFieldResult, $expectedResult)
     {
         Functions\when('get_field')->justReturn($getFieldResult);
-        $this->assertEquals($expectedResult, $this->assignment->populateNotificationSender($args, 1));
+        $this->assertEquals($expectedResult, $this->assignment->populateNotificationSender($args, $this->post->ID));
     }
 
     public function notificationSenderProvider(): array

--- a/source/tests/php/EmployeeTest.php
+++ b/source/tests/php/EmployeeTest.php
@@ -9,6 +9,20 @@ use VolunteerManager\Employee as Employee;
 
 class EmployeeTest extends PluginTestCase
 {
+
+    private $employee;
+    private object $post;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->post = new \stdClass();
+        $this->post->ID = 99;
+
+        $this->employee = new Employee();
+    }
+
     /**
      * @throws ExpectationArgsRequired
      */
@@ -21,5 +35,61 @@ class EmployeeTest extends PluginTestCase
             ->with('init', [$employee, 'insertEmploymentStatusTerms']);
 
         $employee->addHooks();
+    }
+
+    /**
+     * @dataProvider populateNotificationReceiverProvider
+     */
+    public function testPopulateNotificationWithSubmitter($args, $expectedResult, $getFieldResult)
+    {
+        Functions\when('get_field')->justReturn($getFieldResult);
+        $this->assertEquals(
+            $expectedResult,
+            $this->employee->populateNotificationWithReceiver($args, $this->post->ID)
+        );
+    }
+
+    public function populateNotificationReceiverProvider(): array
+    {
+        return [
+            "Existing email address" => [
+                [
+                    'to' => '',
+                    'from' => 'from@email.com',
+                    'message' => [
+                        'subject' => 'subject',
+                        'content' => 'content',
+                    ]
+                ],
+                [
+                    'to' => 'foo@bar.com',
+                    'from' => 'from@email.com',
+                    'message' => [
+                        'subject' => 'subject',
+                        'content' => 'content',
+                    ]
+                ],
+                'foo@bar.com'
+            ],
+            "Missing email address" => [
+                [
+                    'to' => '',
+                    'from' => 'from@email.com',
+                    'message' => [
+                        'subject' => 'subject',
+                        'content' => 'content',
+                    ]
+                ],
+                [
+                    'to' => '',
+                    'from' => 'from@email.com',
+                    'message' => [
+                        'subject' => 'subject',
+                        'content' => 'content',
+                    ]
+                ],
+                null
+            ],
+        ];
     }
 }

--- a/source/tests/php/EmployeeTest.php
+++ b/source/tests/php/EmployeeTest.php
@@ -28,13 +28,11 @@ class EmployeeTest extends PluginTestCase
      */
     public function testAddHooks()
     {
-        $employee = new Employee();
-
         Functions\expect('add_action')
             ->once()
-            ->with('init', [$employee, 'insertEmploymentStatusTerms']);
+            ->with('init', [$this->employee, 'insertEmploymentStatusTerms']);
 
-        $employee->addHooks();
+        $this->employee->addHooks();
     }
 
     /**

--- a/source/tests/php/EmployeeTest.php
+++ b/source/tests/php/EmployeeTest.php
@@ -43,10 +43,7 @@ class EmployeeTest extends PluginTestCase
     public function testPopulateNotificationWithSubmitter($args, $getFieldResult, $expectedResult)
     {
         Functions\when('get_field')->justReturn($getFieldResult);
-        $this->assertEquals(
-            $expectedResult,
-            $this->employee->populateNotificationWithReceiver($args, $this->post->ID)
-        );
+        $this->assertEquals($expectedResult, $this->employee->populateNotificationWithReceiver($args, $this->post->ID));
     }
 
     public function populateNotificationReceiverProvider(): array

--- a/source/tests/php/EmployeeTest.php
+++ b/source/tests/php/EmployeeTest.php
@@ -40,7 +40,7 @@ class EmployeeTest extends PluginTestCase
     /**
      * @dataProvider populateNotificationReceiverProvider
      */
-    public function testPopulateNotificationWithSubmitter($args, $expectedResult, $getFieldResult)
+    public function testPopulateNotificationWithSubmitter($args, $getFieldResult, $expectedResult)
     {
         Functions\when('get_field')->justReturn($getFieldResult);
         $this->assertEquals(
@@ -52,43 +52,15 @@ class EmployeeTest extends PluginTestCase
     public function populateNotificationReceiverProvider(): array
     {
         return [
-            "Existing email address" => [
-                [
-                    'to' => '',
-                    'from' => 'from@email.com',
-                    'message' => [
-                        'subject' => 'subject',
-                        'content' => 'content',
-                    ]
-                ],
-                [
-                    'to' => 'foo@bar.com',
-                    'from' => 'from@email.com',
-                    'message' => [
-                        'subject' => 'subject',
-                        'content' => 'content',
-                    ]
-                ],
-                'foo@bar.com'
+            [
+                ['to' => '', 'from' => '', 'message' => ['subject' => 'Subject', 'content' => 'Content']],
+                'foo@email.bar',
+                ['to' => 'foo@email.bar', 'from' => '', 'message' => ['subject' => 'Subject', 'content' => 'Content']]
             ],
-            "Missing email address" => [
-                [
-                    'to' => '',
-                    'from' => 'from@email.com',
-                    'message' => [
-                        'subject' => 'subject',
-                        'content' => 'content',
-                    ]
-                ],
-                [
-                    'to' => '',
-                    'from' => 'from@email.com',
-                    'message' => [
-                        'subject' => 'subject',
-                        'content' => 'content',
-                    ]
-                ],
-                null
+            [
+                ['to' => '', 'from' => '', 'message' => ['subject' => 'Subject', 'content' => 'Content']],
+                null,
+                ['to' => '', 'from' => '', 'message' => ['subject' => 'Subject', 'content' => 'Content']]
             ],
         ];
     }

--- a/source/tests/php/Notification/NotificationHandlerTest.php
+++ b/source/tests/php/Notification/NotificationHandlerTest.php
@@ -20,7 +20,7 @@ class NotificationHandlerTest extends PluginTestCase
     }
 
     private static array $config = [
-        [
+        "Some test" => [
             'key' => 'post_approved',
             'taxonomy' => 'custom_taxonomy',
             'oldValue' => 'foo',
@@ -35,7 +35,7 @@ class NotificationHandlerTest extends PluginTestCase
                 'operator' => 'EQUAL'
             ]
         ],
-        [
+        "Other test" => [
             'key' => 'other',
             'taxonomy' => 'other_taxonomy',
             'oldValue' => 'old',

--- a/source/tests/php/Notification/NotificationHandlerTest.php
+++ b/source/tests/php/Notification/NotificationHandlerTest.php
@@ -20,22 +20,34 @@ class NotificationHandlerTest extends PluginTestCase
     }
 
     private static array $config = [
-        'post_type' => [
-            'taxonomy' => [
-                [
-                    'key' => 'post_approved',
-                    'oldValue' => 'foo',
-                    'newValue' => 'bar',
-                    'message' => [
-                        'subject' => 'Subject',
-                        'content' => 'Content',
-                    ],
-                    'rule' => [
-                        'key' => 'foo_key',
-                        'value' => 'foo',
-                        'operator' => 'EQUAL'
-                    ]
-                ],
+        [
+            'key' => 'post_approved',
+            'taxonomy' => 'custom_taxonomy',
+            'oldValue' => 'foo',
+            'newValue' => 'bar',
+            'message' => [
+                'subject' => 'Subject',
+                'content' => 'Content',
+            ],
+            'rule' => [
+                'key' => 'foo_key',
+                'value' => 'foo',
+                'operator' => 'EQUAL'
+            ]
+        ],
+        [
+            'key' => 'other',
+            'taxonomy' => 'other_taxonomy',
+            'oldValue' => 'old',
+            'newValue' => 'new',
+            'message' => [
+                'subject' => 'Subject',
+                'content' => 'Content',
+            ],
+            'rule' => [
+                'key' => 'foo_key',
+                'value' => 'bar',
+                'operator' => 'NOT_EQUAL'
             ]
         ]
     ];
@@ -97,13 +109,32 @@ class NotificationHandlerTest extends PluginTestCase
         $this->assertFalse($result);
     }
 
-    public function testGetNotifications()
+    /**
+     * @dataProvider getNotificationsProvider
+     */
+    public function testGetTaxonomyNotifications($expected)
     {
-        $result = $this->notificationHandler->getNotifications('post_type', 'taxonomy');
-        $this->assertEquals($result, self::$config['post_type']['taxonomy']);
+        $actual = $this->notificationHandler->getNotificationsByTaxonomy(self::$config, 'custom_taxonomy');
+        $this->assertEquals($expected, $actual);
+    }
 
-        $result = $this->notificationHandler->getNotifications('post_type', 'unknown_taxonomy');
-        $this->assertEquals([], $result);
+    public function getNotificationsProvider(): array
+    {
+        return [[[[
+            'key' => 'post_approved',
+            'taxonomy' => 'custom_taxonomy',
+            'oldValue' => 'foo',
+            'newValue' => 'bar',
+            'message' => [
+                'subject' => 'Subject',
+                'content' => 'Content',
+            ],
+            'rule' => [
+                'key' => 'foo_key',
+                'value' => 'foo',
+                'operator' => 'EQUAL'
+            ]
+        ]]]];
     }
 
     /**
@@ -153,21 +184,37 @@ class NotificationHandlerTest extends PluginTestCase
         ];
     }
 
-    public function testCombineOldAndNewValues(): void
+    /**
+     * @dataProvider oldAndNewValuesProvider
+     */
+    public function testCombineOldAndNewValues($expected, $oldValues, $newValues): void
     {
-        $oldValues = [1, 2, 3];
-        $newValues = [4, 5, 6];
-
-        $expectedCombinedValues = [
-            ["oldValue" => 1, "newValue" => 4],
-            ["oldValue" => 2, "newValue" => 5],
-            ["oldValue" => 3, "newValue" => 6],
-        ];
-
         $this->assertEquals(
-            $expectedCombinedValues,
+            $expected,
             $this->notificationHandler->combineOldAndNewValues($oldValues, $newValues)
         );
     }
+
+    public function oldAndNewValuesProvider(): array
+    {
+        return [
+            "Existing new and old values" => [
+                [
+                    ["oldValue" => 1, "newValue" => 4],
+                    ["oldValue" => 2, "newValue" => 5],
+                    ["oldValue" => 3, "newValue" => 6],
+                ],
+                [1, 2, 3],
+                [4, 5, 6]
+            ],
+            "Empty old value" => [
+                [["oldValue" => null, "newValue" => 1]], [], [1]
+            ],
+            "Empty new value" => [
+                [], [1], []
+            ],
+        ];
+    }
+
 
 }


### PR DESCRIPTION
Changed notifications config to be flattened and added taxonomy field instead to follow this structure:
`
    [
        "Notification description" => [
            'key' => 'post_approved',
            'taxonomy' => 'custom_taxonomy',
            'oldValue' => 'foo',
            'newValue' => 'bar',
            'message' => [
                'subject' => 'Subject',
                'content' => 'Content',
            ],
            'rule' => [
                'key' => 'foo_key',
                'value' => 'foo',
                'operator' => 'EQUAL'
            ]
        ]
    ];
`

Then I implemented the new structure and added new notification when a new volunteer is registered. 