### PR TITLE
Add support for colors when inserting taxonomy terms

### DIFF
--- a/source/php/AssignmentConfiguration.php
+++ b/source/php/AssignmentConfiguration.php
@@ -11,7 +11,7 @@ class AssignmentConfiguration
                 'name' => __('Approved', 'api-volunteer-manager'),
                 'slug' => 'approved',
                 'description' => __('Approved assignment', 'api-volunteer-manager'),
-                'color' => '#EEE'
+                'color' => '#1e73be'
             ],
             [
                 'name' => __('Ongoing', 'api-volunteer-manager'),
@@ -23,13 +23,13 @@ class AssignmentConfiguration
                 'name' => __('Pending', 'api-volunteer-manager'),
                 'slug' => 'pending',
                 'description' => __('Pending assignment', 'api-volunteer-manager'),
-                'color' => '#EEE'
+                'color' => '#dd9933'
             ],
             [
-                'name' => __('Recurring', 'api-volunteer-manager'),
-                'slug' => 'recurring',
-                'description' => __('Recurring assignment', 'api-volunteer-manager'),
-                'color' => '#8224e3'
+                'name' => __('Denied', 'api-volunteer-manager'),
+                'slug' => 'denied',
+                'description' => __('Denied assignment', 'api-volunteer-manager'),
+                'color' => '#dd3333'
             ]
         ];
     }

--- a/source/php/Entity/Taxonomy.php
+++ b/source/php/Entity/Taxonomy.php
@@ -2,6 +2,7 @@
 
 namespace VolunteerManager\Entity;
 
+use VolunteerManager\Helper\Field;
 use WP_Error;
 
 class Taxonomy
@@ -87,6 +88,10 @@ class Taxonomy
             );
 
             if (!is_wp_error($result)) {
+                if (isset($term['color'])) {
+                    Field::update('taxonomy_color', $term['color'], $this->slug . '_' . $result['term_id']);
+                }
+
                 $inserted_terms[] = $result;
             }
         }

--- a/source/php/Helper/Field.php
+++ b/source/php/Helper/Field.php
@@ -8,4 +8,9 @@ class Field
     {
       return get_field($selector, $id, $formatValue);
     }
+
+    public static function update($selector, $value, $id)
+    {
+        return update_field($selector, $value, $id);
+    }
 }


### PR DESCRIPTION
### Description
This pull request adds support for setting colors when inserting taxonomy terms. The changes will allow users to assign colors to status terms upon creation, providing a more visually informative representation of the different statuses.

### Changes

1.    Updated AssignmentConfiguration to include colors for each term in the getStatusTerms method.
2.   Modified Taxonomy class's insertTerms method to update the color field for a term if the color is set in the term data.
3.    Added a new update method to the Field class that updates the value of a field for a given ID.
4.    Updated test cases in TaxonomyTest to include tests for inserting terms with and without colors.

Modified Files

*    source/php/AssignmentConfiguration.php
  *  source/php/Entity/Taxonomy.php
   * source/php/Helper/Field.php

Testing

*    Ensure all existing test cases pass.
* Test if colors are correctly displayed when setting status for a assignment in the admin.