### PR TITLE
Feat/application post type cu 865bzwgmv

### DIFF
--- a/source/php/App.php
+++ b/source/php/App.php
@@ -2,7 +2,6 @@
 
 namespace VolunteerManager;
 
-use VolunteerManager\Entity\Term;
 use VolunteerManager\Helper\CacheBust;
 use VolunteerManager\Notification\NotificationsConfig;
 use VolunteerManager\Notification\EmailNotificationSender;
@@ -29,6 +28,8 @@ class App
 
         //General
         new Api();
+        $admin = new Admin();
+        $admin->addHooks();
 
         //Post types
         $assignment = new Assignment();
@@ -37,7 +38,8 @@ class App
         $employee = new Employee();
         $employee->addHooks();
 
-        (new Admin())->addHooks();
+        $application = new Application(...ApplicationConfiguration::getPostTypeArgs());
+        $application->addHooks();
     }
 
     /**

--- a/source/php/Application.php
+++ b/source/php/Application.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace VolunteerManager;
+
+use VolunteerManager\Entity\PostTypeNew;
+use VolunteerManager\Entity\Taxonomy as Taxonomy;
+
+class Application extends PostTypeNew
+{
+    public function addHooks(): void
+    {
+        parent::addHooks();
+
+        add_action('init', [$this, 'registerStatusTaxonomy']);
+    }
+
+    /**
+     * Register status taxonomy
+     *
+     * @return void
+     */
+    public function registerStatusTaxonomy(): void
+    {
+        $statusTaxonomy = new Taxonomy(
+            'Application statuses',
+            'Application status',
+            'application-status',
+            array($this->slug),
+            array(
+                'hierarchical' => false,
+                'show_ui' => false
+            )
+        );
+
+        $statusTaxonomy->registerTaxonomy();
+    }
+}

--- a/source/php/ApplicationConfiguration.php
+++ b/source/php/ApplicationConfiguration.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace VolunteerManager;
+
+use VolunteerManager\Helper\Icon as Icon;
+
+class ApplicationConfiguration
+{
+    public static function getPostTypeArgs(): array
+    {
+        return [
+            'slug' => 'application',
+            'namePlural' => 'applications',
+            'nameSingular' => 'application',
+            'args' => [
+                'description' => __('Applications', AVM_TEXT_DOMAIN),
+                'menu_icon' => Icon::get('person'),
+                'public' => false,
+                'show_ui' => true,
+                'show_in_nav_menus' => true,
+                'exclude_from_search' => true,
+                'supports' => false,
+            ]
+        ];
+    }
+}

--- a/source/php/Entity/PostType.php
+++ b/source/php/Entity/PostType.php
@@ -40,21 +40,21 @@ class PostType
      * Register the actual post type
      * @return string Registered post type slug
      */
-    public function registerPostType() : string
+    public function registerPostType(): string
     {
         $labels = array(
-            'name'                => $this->namePlural,
-            'singular_name'       => $this->nameSingular,
-            'add_new'             => sprintf(__('Add new %s', 'api-volunteer-manager'), $this->nameSingular),
-            'add_new_item'        => sprintf(__('Add new %s', 'api-volunteer-manager'), $this->nameSingular),
-            'edit_item'           => sprintf(__('Edit %s', 'api-volunteer-manager'), $this->nameSingular),
-            'new_item'            => sprintf(__('New %s', 'api-volunteer-manager'), $this->nameSingular),
-            'view_item'           => sprintf(__('View %s', 'api-volunteer-manager'), $this->nameSingular),
-            'search_items'        => sprintf(__('Search %s', 'api-volunteer-manager'), $this->namePlural),
-            'not_found'           => sprintf(__('No %s found', 'api-volunteer-manager'), $this->namePlural),
-            'not_found_in_trash'  => sprintf(__('No %s found in trash', 'api-volunteer-manager'), $this->namePlural),
-            'parent_item_colon'   => sprintf(__('Parent %s:', 'api-volunteer-manager'), $this->nameSingular),
-            'menu_name'           => $this->namePlural,
+            'name' => $this->namePlural,
+            'singular_name' => $this->nameSingular,
+            'add_new' => sprintf(__('Add new %s', 'api-volunteer-manager'), $this->nameSingular),
+            'add_new_item' => sprintf(__('Add new %s', 'api-volunteer-manager'), $this->nameSingular),
+            'edit_item' => sprintf(__('Edit %s', 'api-volunteer-manager'), $this->nameSingular),
+            'new_item' => sprintf(__('New %s', 'api-volunteer-manager'), $this->nameSingular),
+            'view_item' => sprintf(__('View %s', 'api-volunteer-manager'), $this->nameSingular),
+            'search_items' => sprintf(__('Search %s', 'api-volunteer-manager'), $this->namePlural),
+            'not_found' => sprintf(__('No %s found', 'api-volunteer-manager'), $this->namePlural),
+            'not_found_in_trash' => sprintf(__('No %s found in trash', 'api-volunteer-manager'), $this->namePlural),
+            'parent_item_colon' => sprintf(__('Parent %s:', 'api-volunteer-manager'), $this->nameSingular),
+            'menu_name' => $this->namePlural,
         );
 
         $this->args['labels'] = $labels;
@@ -72,7 +72,7 @@ class PostType
      * @param callback $contentCallback Callback function for displaying
      *                                  column content (params: $columnKey, $postId)
      */
-    public function addTableColumn($key, $title, $sortable = false, $contentCallback = false) : bool
+    public function addTableColumn($key, $title, $sortable = false, $contentCallback = false): bool
     {
         $this->tableColumns[$key] = $title;
 
@@ -89,10 +89,10 @@ class PostType
 
     /**
      * Set up table columns
-     * @param  array $columns Default columns
+     * @param array $columns Default columns
      * @return array          New columns
      */
-    public function tableColumns($columns) : array
+    public function tableColumns($columns): array
     {
         if (!empty($this->tableColumns) && is_array($this->tableColumns)) {
             $columns = array_merge(
@@ -107,13 +107,13 @@ class PostType
 
     /**
      * Setup sortable columns
-     * @param  array $columns Default columns
+     * @param array $columns Default columns
      * @return array          New columns
      */
-    public function tableSortableColumns($columns) : array
+    public function tableSortableColumns($columns): array
     {
         if (!empty($this->tableSortableColumns) && is_array($this->tableSortableColumns)) {
-            $columns = $this->tableColumns;
+            $columns = $this->tableSortableColumns;
         }
 
         return unserialize(strtolower(serialize($columns)));
@@ -121,8 +121,8 @@ class PostType
 
     /**
      * Set table column content with callback functions
-     * @param  string  $column Key of the column
-     * @param  integer $postId Post id of the current row in table
+     * @param string  $column Key of the column
+     * @param integer $postId Post id of the current row in table
      * @return void
      */
     public function tableColumnsContent($column, $postId)

--- a/source/php/Entity/PostTypeInterface.php
+++ b/source/php/Entity/PostTypeInterface.php
@@ -8,7 +8,7 @@ interface PostTypeInterface
 
     public function registerPostType(): void;
 
-    public function addTableColumn(string $key, string $title, bool $sortable = false, callable|false $contentCallback = false): bool;
+    public function addTableColumn(string $key, string $title, bool $sortable = false, $contentCallback = null): void;
 
     public function setTableColumns(array $columns): array;
 

--- a/source/php/Entity/PostTypeInterface.php
+++ b/source/php/Entity/PostTypeInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace VolunteerManager\Entity;
+
+interface PostTypeInterface
+{
+    public function addHooks(): void;
+
+    public function registerPostType(): void;
+
+    public function addTableColumn(string $key, string $title, bool $sortable = false, callable|false $contentCallback = false): bool;
+
+    public function setTableColumns(array $columns): array;
+
+    public function tableSortableColumns(array $columns): array;
+
+    public function tableColumnsContent(string $column, int $postId): void;
+}

--- a/source/php/Entity/PostTypeNew.php
+++ b/source/php/Entity/PostTypeNew.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace VolunteerManager\Entity;
+
+class PostTypeNew implements PostTypeInterface
+{
+    public string $slug;
+    public string $namePlural;
+    public string $nameSingular;
+    public array $labels;
+    public array $args;
+    public array $tableColumns = array();
+    public array $tableSortableColumns = array();
+    public array $tableColumnsContentCallback = array();
+    
+    public function __construct(string $slug, string $namePlural, string $nameSingular, array $args = array(), array $labels = array())
+    {
+        $this->slug = $slug;
+        $this->namePlural = $namePlural;
+        $this->nameSingular = $nameSingular;
+        $this->args = $args;
+        $this->labels = $labels;
+    }
+
+    /**
+     * Register wp actions and filters
+     * @return void
+     */
+    public function addHooks(): void
+    {
+        add_action('init', [$this, 'registerPostType']);
+        add_action('manage_' . $this->slug . '_posts_custom_column', [$this, 'tableColumnsContent'], 10, 2);
+        add_filter('manage_edit-' . $this->slug . '_columns', [$this, 'setTableColumns']);
+        add_filter('manage_edit-' . $this->slug . '_sortable_columns', [$this, 'tableSortableColumns']);
+    }
+
+    /**
+     * Registers a custom post type
+     * @return void
+     */
+    public function registerPostType(): void
+    {
+        $labels = array_merge(
+            array(
+                'name' => ucfirst($this->namePlural),
+                'singular_name' => ucfirst($this->nameSingular),
+                'add_new' => sprintf(__('Add new %s', AVM_TEXT_DOMAIN), strtolower($this->nameSingular)),
+                'add_new_item' => sprintf(__('Add new %s', AVM_TEXT_DOMAIN), strtolower($this->nameSingular)),
+                'edit_item' => sprintf(__('Edit %s', AVM_TEXT_DOMAIN), strtolower($this->nameSingular)),
+                'new_item' => sprintf(__('New %s', AVM_TEXT_DOMAIN), strtolower($this->nameSingular)),
+                'view_item' => sprintf(__('View %s', AVM_TEXT_DOMAIN), strtolower($this->nameSingular)),
+                'search_items' => sprintf(__('Search %s', AVM_TEXT_DOMAIN), strtolower($this->namePlural)),
+                'not_found' => sprintf(__('No %s found', AVM_TEXT_DOMAIN), strtolower($this->namePlural)),
+                'not_found_in_trash' => sprintf(__('No %s found in trash', AVM_TEXT_DOMAIN), strtolower($this->namePlural)),
+                'parent_item_colon' => sprintf(__('Parent %s:', AVM_TEXT_DOMAIN), strtolower($this->nameSingular)),
+                'menu_name' => ucfirst($this->namePlural),
+            ),
+            $this->labels
+        );
+
+        $mergedArgs = array_merge(
+            array(
+                'labels' => $labels,
+                'rewrite' => array(
+                    'slug' => $this->slug,
+                    'with_front' => false
+                ),
+            ),
+            $this->args
+        );
+
+        register_post_type($this->slug, $mergedArgs);
+    }
+
+    /**
+     * Adds a column to the admin list table
+     * @param string         $key             Column key
+     * @param string         $title           Column title
+     * @param boolean        $sortable        Sortable or not
+     * @param callback|false $contentCallback Callback function for displaying
+     *                                        column content (params: $columnKey, $postId)
+     */
+    public function addTableColumn(string $key, string $title, bool $sortable = false, callable|false $contentCallback = false): bool
+    {
+        $this->tableColumns[$key] = $title;
+
+        if ($sortable === true) {
+            $this->tableSortableColumns[$key] = $key;
+        }
+
+        if ($contentCallback !== false) {
+            $this->tableColumnsContentCallback[$key] = $contentCallback;
+        }
+
+        return true;
+    }
+
+    /**
+     * Set up table columns
+     * @param array $columns Default columns
+     * @return array          New columns
+     */
+    public function setTableColumns(array $columns): array
+    {
+        if (!empty($this->tableColumns)) {
+            $columns = array_merge(
+                array_splice($columns, 0, 2),
+                $this->tableColumns,
+                array_splice($columns, 0, count($columns))
+            );
+        }
+
+        return $columns;
+    }
+
+    /**
+     * Setup sortable columns
+     * @param array $columns Default columns
+     * @return array          New columns
+     */
+    public function tableSortableColumns(array $columns): array
+    {
+        if (!empty($this->tableSortableColumns)) {
+            $columns = $this->tableSortableColumns;
+        }
+
+        return unserialize(strtolower(serialize($columns)));
+    }
+
+    /**
+     * Set table column content with callback functions
+     * @param string  $column Key of the column
+     * @param integer $postId Post id of the current row in table
+     * @return void
+     */
+    public function tableColumnsContent(string $column, int $postId): void
+    {
+        if (!isset($this->tableColumnsContentCallback[$column])) {
+            return;
+        }
+
+        call_user_func_array($this->tableColumnsContentCallback[$column], array($column, $postId));
+    }
+}

--- a/source/php/Entity/PostTypeNew.php
+++ b/source/php/Entity/PostTypeNew.php
@@ -12,7 +12,7 @@ class PostTypeNew implements PostTypeInterface
     public array $tableColumns = array();
     public array $tableSortableColumns = array();
     public array $tableColumnsContentCallback = array();
-    
+
     public function __construct(string $slug, string $namePlural, string $nameSingular, array $args = array(), array $labels = array())
     {
         $this->slug = $slug;
@@ -74,13 +74,14 @@ class PostTypeNew implements PostTypeInterface
 
     /**
      * Adds a column to the admin list table
-     * @param string         $key             Column key
-     * @param string         $title           Column title
-     * @param boolean        $sortable        Sortable or not
-     * @param callback|false $contentCallback Callback function for displaying
+     * @param string        $key              Column key
+     * @param string        $title            Column title
+     * @param boolean       $sortable         Sortable or not
+     * @param callable|null $contentCallback  Callback function for displaying
      *                                        column content (params: $columnKey, $postId)
+     * @return void
      */
-    public function addTableColumn(string $key, string $title, bool $sortable = false, callable|false $contentCallback = false): bool
+    public function addTableColumn(string $key, string $title, bool $sortable = false, $contentCallback = null): void
     {
         $this->tableColumns[$key] = $title;
 
@@ -88,11 +89,9 @@ class PostTypeNew implements PostTypeInterface
             $this->tableSortableColumns[$key] = $key;
         }
 
-        if ($contentCallback !== false) {
+        if ($contentCallback) {
             $this->tableColumnsContentCallback[$key] = $contentCallback;
         }
-
-        return true;
     }
 
     /**

--- a/source/tests/php/Entity/PostTypeTest.php
+++ b/source/tests/php/Entity/PostTypeTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace php;
+namespace php\Entity;
 
-use PluginTestCase\PluginTestCase;
 use Brain\Monkey\Functions;
+use PluginTestCase\PluginTestCase;
 use VolunteerManager\Entity\PostTypeNew;
 
 class PostTypeTest extends PluginTestCase
@@ -132,7 +132,7 @@ class PostTypeTest extends PluginTestCase
             echo $postId;
         };
 
-        $customPostType->tableColumnsContentCallback['column1'] = $mockCallback;
+        $customPostType->tableColumnsContentCallback = ['column1' => $mockCallback];
 
         Functions\expect('call_user_func_array')
             ->once()
@@ -140,5 +140,4 @@ class PostTypeTest extends PluginTestCase
 
         $customPostType->tableColumnsContent('column1', 123);
     }
-
 }

--- a/source/tests/php/Entity/PostTypeTest.php
+++ b/source/tests/php/Entity/PostTypeTest.php
@@ -140,4 +140,31 @@ class PostTypeTest extends PluginTestCase
 
         $customPostType->tableColumnsContent('column1', 123);
     }
+
+    /**
+     * Alternative test for tableColumnsContent method
+     *
+     * @dataProvider postTypeProvider
+     */
+    public function testTableColumnsContentV2($args)
+    {
+        $customPostType = new PostTypeNew(...$args);
+
+        $columnKey = 'column1';
+        $postId = 123;
+
+        $callback = function ($column, $id) {
+            echo "Column: {$column}, post ID: {$id}";
+        };
+
+        $customPostType->tableColumnsContentCallback = [$columnKey => $callback];
+
+        ob_start();
+        $customPostType->tableColumnsContent($columnKey, $postId);
+        $output = ob_get_clean();
+
+        $expectedOutput = "Column: {$columnKey}, post ID: {$postId}";
+        $this->assertEquals($expectedOutput, $output);
+    }
+
 }

--- a/source/tests/php/Entity/PostTypeTest.php
+++ b/source/tests/php/Entity/PostTypeTest.php
@@ -81,8 +81,18 @@ class PostTypeTest extends PluginTestCase
     public function testAddTableColumn($args)
     {
         $customPostType = new PostTypeNew(...$args);
-        $result = $customPostType->addTableColumn('foo', 'Foo', false, fn() => "foo");
-        $this->assertTrue($result);
+        $customPostType->addTableColumn('foo', 'Foo', true, fn() => "callback");
+        $this->assertEquals(['foo' => 'Foo'], $customPostType->tableColumns);
+    }
+
+    /**
+     * @dataProvider postTypeProvider
+     */
+    public function testAddTableColumnCallback($args)
+    {
+        $customPostType = new PostTypeNew(...$args);
+        $customPostType->addTableColumn('foo', 'Foo', true, fn() => "some callback");
+        $this->assertEquals(['foo' => fn() => "some callback"], $customPostType->tableColumnsContentCallback);
     }
 
     /**

--- a/source/tests/php/Entity/PostTypeTest.php
+++ b/source/tests/php/Entity/PostTypeTest.php
@@ -120,33 +120,8 @@ class PostTypeTest extends PluginTestCase
 
     /**
      * @dataProvider postTypeProvider
-     * @throws \Brain\Monkey\Expectation\Exception\ExpectationArgsRequired
      */
     public function testTableColumnsContent($args)
-    {
-        $customPostType = new PostTypeNew(...$args);
-
-        $mockCallback = function (string $column, int $postId) {
-            $this->assertEquals('column1', $column);
-            $this->assertEquals(123, $postId);
-            echo $postId;
-        };
-
-        $customPostType->tableColumnsContentCallback = ['column1' => $mockCallback];
-
-        Functions\expect('call_user_func_array')
-            ->once()
-            ->with($mockCallback, ['column1', 123]);
-
-        $customPostType->tableColumnsContent('column1', 123);
-    }
-
-    /**
-     * Alternative test for tableColumnsContent method
-     *
-     * @dataProvider postTypeProvider
-     */
-    public function testTableColumnsContentV2($args)
     {
         $customPostType = new PostTypeNew(...$args);
 
@@ -166,5 +141,4 @@ class PostTypeTest extends PluginTestCase
         $expectedOutput = "Column: {$columnKey}, post ID: {$postId}";
         $this->assertEquals($expectedOutput, $output);
     }
-
 }

--- a/source/tests/php/PostTypeTest.php
+++ b/source/tests/php/PostTypeTest.php
@@ -118,5 +118,27 @@ class PostTypeTest extends PluginTestCase
         $this->assertEquals(['column2'], $result);
     }
 
+    /**
+     * @dataProvider postTypeProvider
+     * @throws \Brain\Monkey\Expectation\Exception\ExpectationArgsRequired
+     */
+    public function testTableColumnsContent($args)
+    {
+        $customPostType = new PostTypeNew(...$args);
+
+        $mockCallback = function (string $column, int $postId) {
+            $this->assertEquals('column1', $column);
+            $this->assertEquals(123, $postId);
+            echo $postId;
+        };
+
+        $customPostType->tableColumnsContentCallback['column1'] = $mockCallback;
+
+        Functions\expect('call_user_func_array')
+            ->once()
+            ->with($mockCallback, ['column1', 123]);
+
+        $customPostType->tableColumnsContent('column1', 123);
+    }
 
 }

--- a/source/tests/php/PostTypeTest.php
+++ b/source/tests/php/PostTypeTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace php;
+
+use PluginTestCase\PluginTestCase;
+use Brain\Monkey\Functions;
+use VolunteerManager\Entity\PostTypeNew;
+
+class PostTypeTest extends PluginTestCase
+{
+    public function postTypeProvider(): array
+    {
+        return [
+            [
+                [
+                    'slug' => 'example',
+                    'namePlural' => 'examples',
+                    'nameSingular' => 'example',
+                    'args' => [
+                        'label' => 'Custom label',
+                        'public' => false,
+                        'menu_position' => 20,
+                    ],
+                ],
+                [
+                    'public' => false,
+                    'menu_position' => 20,
+                    'rewrite' => [
+                        'slug' => 'example',
+                        'with_front' => false
+                    ],
+                    'label' => 'Custom label',
+                    'labels' => [
+                        'name' => 'Examples',
+                        'singular_name' => 'Example',
+                        'add_new' => 'Add new example',
+                        'add_new_item' => 'Add new example',
+                        'edit_item' => 'Edit example',
+                        'new_item' => 'New example',
+                        'view_item' => 'View example',
+                        'search_items' => 'Search examples',
+                        'not_found' => 'No examples found',
+                        'not_found_in_trash' => 'No examples found in trash',
+                        'parent_item_colon' => 'Parent example:',
+                        'menu_name' => 'Examples',
+                    ],
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider postTypeProvider
+     */
+    public function testAddHooks($args)
+    {
+        $customPostType = new PostTypeNew(...$args);
+        $customPostType->addHooks();
+        self::assertNotFalse(has_action('init', [$customPostType, 'registerPostType']));
+        self::assertNotFalse(has_action('manage_' . $customPostType->slug . '_posts_custom_column', [$customPostType, 'tableColumnsContent']));
+        self::assertNotFalse(has_filter('manage_edit-' . $customPostType->slug . '_columns', [$customPostType, 'setTableColumns']));
+        self::assertNotFalse(has_filter('manage_edit-' . $customPostType->slug . '_sortable_columns', [$customPostType, 'tableSortableColumns']));
+    }
+
+    /**
+     * @dataProvider postTypeProvider
+     * @throws \Brain\Monkey\Expectation\Exception\ExpectationArgsRequired
+     */
+    public function testRegisterPostType($args, $expectedArgs)
+    {
+        $customPostType = new PostTypeNew(...$args);
+        Functions\expect('register_post_type')
+            ->once()
+            ->with($customPostType->slug, $expectedArgs);
+        $customPostType->registerPostType();
+    }
+
+    /**
+     * @dataProvider postTypeProvider
+     */
+    public function testAddTableColumn($args)
+    {
+        $customPostType = new PostTypeNew(...$args);
+        $result = $customPostType->addTableColumn('foo', 'Foo', false, fn() => "foo");
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @dataProvider postTypeProvider
+     */
+    public function testSetTableColumns($args)
+    {
+        $customPostType = new PostTypeNew(...$args);
+        $customPostType->tableColumns = [
+            'column1' => 'Column 1',
+        ];
+        $result = $customPostType->setTableColumns(['column2' => 'Column 2']);
+        $this->assertEquals(
+            ['column1' => 'Column 1', 'column2' => 'Column 2'],
+            $result
+        );
+    }
+
+    /**
+     * @dataProvider postTypeProvider
+     */
+    public function testTableSortableColumns($args)
+    {
+        $customPostType = new PostTypeNew(...$args);
+        $customPostType->tableColumns = [
+            'column1' => 'Column 1',
+            'column2' => 'Column 2',
+        ];
+        $customPostType->tableSortableColumns = [
+            'column2'
+        ];
+        $result = $customPostType->tableSortableColumns(['column5' => 'Column 5']);
+        $this->assertEquals(['column2'], $result);
+    }
+
+
+}


### PR DESCRIPTION
Crated a new PostType interface + class that can replace the old one. 
It basically does the same thing as the old but it can be extended more easily and does not create new objects in the constructor.  

Also added tests and an example implementation where i created a class called Application(+ config file) that extends the PostTypeNew.

Note: 
I'm not sure if the table handling methods should exist in the post type class or be moved to a separate class?