### PR TITLE
Add taxonomy pills to employee registration status and update test cases

### DIFF
--- a/source/php/Employee.php
+++ b/source/php/Employee.php
@@ -5,6 +5,7 @@ namespace VolunteerManager;
 use \VolunteerManager\Entity\PostType as PostType;
 use \VolunteerManager\Entity\Taxonomy as Taxonomy;
 use \VolunteerManager\Helper\Icon as Icon;
+use VolunteerManager\Helper\Admin\UI as AdminUI;
 
 class Employee
 {
@@ -104,7 +105,9 @@ class Employee
             __('Registration status', AVM_TEXT_DOMAIN),
             true,
             function ($column, $postId) {
-                echo "-";
+                echo AdminUI::createTaxonomyPills(
+                    get_the_terms($postId, 'employee-registration-status'),
+                );
             }
         );
 

--- a/source/php/Employee.php
+++ b/source/php/Employee.php
@@ -4,6 +4,7 @@ namespace VolunteerManager;
 
 use \VolunteerManager\Entity\PostType as PostType;
 use \VolunteerManager\Entity\Taxonomy as Taxonomy;
+use VolunteerManager\Helper\Admin\UI as AdminUI;
 use \VolunteerManager\Helper\Icon as Icon;
 use VolunteerManager\Helper\Admin\UI as AdminUI;
 
@@ -106,7 +107,10 @@ class Employee
             true,
             function ($column, $postId) {
                 echo AdminUI::createTaxonomyPills(
-                    get_the_terms($postId, 'employee-registration-status'),
+                    get_the_terms(
+                        $postId,
+                        'employee-registration-status'
+                    )
                 );
             }
         );

--- a/source/php/Employee.php
+++ b/source/php/Employee.php
@@ -6,7 +6,6 @@ use \VolunteerManager\Entity\PostType as PostType;
 use \VolunteerManager\Entity\Taxonomy as Taxonomy;
 use VolunteerManager\Helper\Admin\UI as AdminUI;
 use \VolunteerManager\Helper\Icon as Icon;
-use VolunteerManager\Helper\Admin\UI as AdminUI;
 
 class Employee
 {

--- a/source/php/EmployeeConfiguration.php
+++ b/source/php/EmployeeConfiguration.php
@@ -9,22 +9,26 @@ class EmployeeConfiguration {
             [
                 'name' => __('New', 'api-volunteer-manager'),
                 'slug' => 'new',
-                'description' => 'New employee. Employee needs to be processed.'
+                'description' => 'New employee. Employee needs to be processed.',
+                'color' => '#eeee22'
             ],
             [
                 'name' => __('Ongoing', 'api-volunteer-manager'),
                 'slug' => 'ongoing',
-                'description' => 'Employee under investigation.'
+                'description' => 'Employee under investigation.',
+                'color' => '#81d742'
             ],
             [
                 'name' => __('Approved', 'api-volunteer-manager'),
                 'slug' => 'approved',
-                'description' => 'Employee approved for assignments.'
+                'description' => 'Employee approved for assignments.',
+                'color' => '#1e73be'
             ],
             [
                 'name' => __('Denied', 'api-volunteer-manager'),
                 'slug' => 'denied',
-                'description' => 'Employee denied. Employee can\'t apply.'
+                'description' => 'Employee denied. Employee can\'t apply.',
+                'color' => '#dd3333'
             ]
         ];
     }

--- a/source/tests/php/EmployeeTest.php
+++ b/source/tests/php/EmployeeTest.php
@@ -126,18 +126,20 @@ class EmployeeTest extends PluginTestCase
 
         $result = $method->invoke($this->employee, $field);
         $this->assertEquals($expectedField, $result);
+
     }
 
     public function acfSetNotesDefaultDateProvider(): array
     {
+        $currentDate = date( 'Y-m-d' );
         return [
             "Test setting default_value when value is empty" => [
                 ['type' => 'date_picker', 'name' => 'notes_date_updated', 'value' => ''],
-                ['type' => 'date_picker', 'name' => 'notes_date_updated', 'value' => '', 'default_value' => '2023-03-23']
+                ['type' => 'date_picker', 'name' => 'notes_date_updated', 'value' => '', 'default_value' => $currentDate]
             ],
             "Test setting default_value when value is not empty" => [
                 ['type' => 'date_picker', 'name' => 'notes_date_updated', 'value' => '2023-03-22'],
-                ['type' => 'date_picker', 'name' => 'notes_date_updated', 'value' => '2023-03-22', 'default_value' => '2023-03-23']
+                ['type' => 'date_picker', 'name' => 'notes_date_updated', 'value' => '2023-03-22', 'default_value' => $currentDate]
             ],
         ];
     }


### PR DESCRIPTION
### Description
This pull request display employee registration status using taxonomy pills in the admin dashboard, adds colors to status terms in `EmployeeConfiguration.php` and updates the test cases in `EmployeeTest.php` to use dynamic dates.

### Changes
1. In `source/php/Employee.php`, updated the `addPostTypeTableColumn` method to display taxonomy pills for employee registration status using the `AdminUI::createTaxonomyPills` method.
2. In `source/php/EmployeeConfiguration.php`, added colors to the status terms for better visibility in the UI.
3. In `source/tests/php/EmployeeTest.php`, updated the test case provider method `acfSetNotesDefaultDateProvider` to use dynamic dates instead of hardcoded values.

### Testing
Please verify the following functionalities:
1. Taxonomy pills for employee registration status are displayed correctly in the admin dashboard.
2. All test cases shall pass successfully.
