### PR TITLE
Feat/application status terms

### DIFF
--- a/source/php/Application.php
+++ b/source/php/Application.php
@@ -7,11 +7,18 @@ use VolunteerManager\Entity\Taxonomy as Taxonomy;
 
 class Application extends PostTypeNew
 {
+    private Taxonomy $applicationTaxonomy;
     public function addHooks(): void
     {
         parent::addHooks();
 
-        add_action('init', [$this, 'registerStatusTaxonomy']);
+        add_action('init', [$this, 'initTaxonomiesAndTerms']);
+    }
+
+    public function initTaxonomiesAndTerms(): void
+    {
+        $this->registerStatusTaxonomy();
+        $this->insertStatusTerms();
     }
 
     /**
@@ -21,7 +28,7 @@ class Application extends PostTypeNew
      */
     public function registerStatusTaxonomy(): void
     {
-        $statusTaxonomy = new Taxonomy(
+        $this->applicationTaxonomy = new Taxonomy(
             'Application statuses',
             'Application status',
             'application-status',
@@ -32,6 +39,11 @@ class Application extends PostTypeNew
             )
         );
 
-        $statusTaxonomy->registerTaxonomy();
+        $this->applicationTaxonomy->registerTaxonomy();
+    }
+
+    public function insertStatusTerms()
+    {
+        return $this->applicationTaxonomy->insertTerms(ApplicationConfiguration::getStatusTerms());
     }
 }

--- a/source/php/Application.php
+++ b/source/php/Application.php
@@ -4,6 +4,7 @@ namespace VolunteerManager;
 
 use VolunteerManager\Entity\PostTypeNew;
 use VolunteerManager\Entity\Taxonomy as Taxonomy;
+use WP_Error;
 
 class Application extends PostTypeNew
 {
@@ -42,6 +43,11 @@ class Application extends PostTypeNew
         $this->applicationTaxonomy->registerTaxonomy();
     }
 
+    /**
+     * Insert status terms
+     *
+     * @return array|WP_Error
+     */
     public function insertStatusTerms()
     {
         return $this->applicationTaxonomy->insertTerms(ApplicationConfiguration::getStatusTerms());

--- a/source/php/ApplicationConfiguration.php
+++ b/source/php/ApplicationConfiguration.php
@@ -23,4 +23,34 @@ class ApplicationConfiguration
             ]
         ];
     }
+
+    public static function getStatusTerms(): array
+    {
+        return [
+            [
+                'name' => __('Pending', AVM_TEXT_DOMAIN),
+                'slug' => 'pending',
+                'description' => 'Application is pending.',
+                'color' => '#dd9933'
+            ],
+            [
+                'name' => __('Ongoing', AVM_TEXT_DOMAIN),
+                'slug' => 'ongoing',
+                'description' => 'Application is under investigation.',
+                'color' => '#81d742'
+            ],
+            [
+                'name' => __('Closed', AVM_TEXT_DOMAIN),
+                'slug' => 'closed',
+                'description' => 'Application is closed.',
+                'color' => '#708090'
+            ],
+            [
+                'name' => __('Denied', AVM_TEXT_DOMAIN),
+                'slug' => 'denied',
+                'description' => 'Application is denied.',
+                'color' => '#dd3333'
+            ]
+        ];
+    }
 }

--- a/source/tests/php/ApplicationTest.php
+++ b/source/tests/php/ApplicationTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace php;
+
+use Brain\Monkey\Expectation\Exception\ExpectationArgsRequired;
+use PluginTestCase\PluginTestCase;
+use VolunteerManager\Application;
+use PHPUnit\Framework\TestCase;
+use VolunteerManager\ApplicationConfiguration;
+use Brain\Monkey\Functions;
+
+class ApplicationTest extends PluginTestCase
+{
+    private Application $application;
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $mockApplicationArgs =
+            [
+            'slug' => 'application',
+            'namePlural' => 'applications',
+            'nameSingular' => 'application',
+            'args' => [
+                'description' => 'Applications',
+                'public' => false,
+                'show_ui' => true,
+                'show_in_nav_menus' => true,
+                'exclude_from_search' => true,
+                'supports' => false,
+            ]
+        ];
+
+        $this->application = new Application(...$mockApplicationArgs);
+
+    }
+
+    /**
+     * @throws ExpectationArgsRequired
+     */
+    public function testInsertStatusTerms()
+    {
+        Functions\expect('')
+
+        Functions\expect('insertTerms')
+            ->once()
+            ->with(ApplicationConfiguration::getStatusTerms())
+            ->andReturn(true);
+
+        $this->application->registerStatusTaxonomy();
+        $insertTermsResult = $this->application->insertStatusTerms();
+
+        $this->assertTrue($insertTermsResult);
+
+    }
+}


### PR DESCRIPTION
### Description

This PR adds functionality to implement application status taxonomy to the existing WordPress plugin. It also initializes the taxonomy terms and adds a test to ensure that the taxonomy terms are inserted correctly.

### Changes Made

*    Added an array of terms to config
*    Implemented application status taxonomy and initialization
*    Started on a test for application
*    Added PHPDoc for insertStatusTerms()
*    Added a test for insertStatusTerms

### Testing

*    Tested by running the new test for insertStatusTerms() in ApplicationTest.php
*    Verified that the application status taxonomy and its terms are created as expected by setting Application.php show_ui to true:
```php
    public function registerStatusTaxonomy(): void
    {
        $this->applicationTaxonomy = new Taxonomy(
            'Application statuses',
            'Application status',
            'application-status',
            array($this->slug),
            array(
                'hierarchical' => false,
                'show_ui' => true            // <= Change from false to true
            )
        );

        $this->applicationTaxonomy->registerTaxonomy();
    }
   ```
And check that statuses are created:
<img width="1134" alt="Screenshot 2023-03-30 at 15 35 01" src="https://user-images.githubusercontent.com/186287/228853363-3264b5b6-c703-4c7d-aa04-64c87e8c5c69.png">
ated for Application in the WP admin:
