### PR TITLE
Feat/jwt validation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
   },
   "minimum-stability": "stable",
   "require": {
-    "helsingborg-stad/acf-export-manager": ">=1.0.0"
+    "helsingborg-stad/acf-export-manager": ">=1.0.0",
+    "firebase/php-jwt": "^6.4"
   },
   "require-dev": {
     "mockery/mockery": "dev-master@dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,71 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "da5be458e0909d5e81fa98b662f76271",
+    "content-hash": "801d5c3a58d0d99691a79b69953540f9",
     "packages": [
+        {
+            "name": "firebase/php-jwt",
+            "version": "v6.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/firebase/php-jwt.git",
+                "reference": "4dd1e007f22a927ac77da5a3fbb067b42d3bc224"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/4dd1e007f22a927ac77da5a3fbb067b42d3bc224",
+                "reference": "4dd1e007f22a927ac77da5a3fbb067b42d3bc224",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1||^8.0"
+            },
+            "require-dev": {
+                "guzzlehttp/guzzle": "^6.5||^7.4",
+                "phpspec/prophecy-phpunit": "^1.1",
+                "phpunit/phpunit": "^7.5||^9.5",
+                "psr/cache": "^1.0||^2.0",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0"
+            },
+            "suggest": {
+                "ext-sodium": "Support EdDSA (Ed25519) signatures",
+                "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Firebase\\JWT\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Neuman Vong",
+                    "email": "neuman+pear@twilio.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Anant Narayanan",
+                    "email": "anant@php.net",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
+            "homepage": "https://github.com/firebase/php-jwt",
+            "keywords": [
+                "jwt",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/firebase/php-jwt/issues",
+                "source": "https://github.com/firebase/php-jwt/tree/v6.4.0"
+            },
+            "time": "2023-02-09T21:01:23+00:00"
+        },
         {
             "name": "helsingborg-stad/acf-export-manager",
             "version": "1.0.11",

--- a/source/php/API/Api.php
+++ b/source/php/API/Api.php
@@ -8,8 +8,8 @@ class Api
 {
     private $postTypes = [
         'assignment',
-        'employer',
-        'employee'
+        'employee',
+        'application'
     ];
 
     private $removableResponseKeys = [

--- a/source/php/API/Auth/AuthenticationDecorator.php
+++ b/source/php/API/Auth/AuthenticationDecorator.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace VolunteerManager\API\Auth;
+
+class AuthenticationDecorator
+{
+    private $callback;
+    private AuthenticationInterface $authentication;
+
+    public function __construct($callback, $authentication)
+    {
+        $this->callback = $callback;
+        $this->authentication = $authentication;
+    }
+
+    public function __invoke($request)
+    {
+        $validatedRequest = $this->authentication->validateRequest($request);
+
+        if (is_wp_error($validatedRequest)) {
+            return $validatedRequest;
+        }
+
+        return call_user_func($this->callback, $validatedRequest);
+    }
+}

--- a/source/php/API/Auth/AuthenticationDecorator.php
+++ b/source/php/API/Auth/AuthenticationDecorator.php
@@ -2,6 +2,8 @@
 
 namespace VolunteerManager\API\Auth;
 
+use WP_REST_Request;
+
 class AuthenticationDecorator
 {
     private $callback;
@@ -13,7 +15,7 @@ class AuthenticationDecorator
         $this->authentication = $authentication;
     }
 
-    public function __invoke($request)
+    public function __invoke(WP_REST_Request $request)
     {
         $validatedRequest = $this->authentication->validateRequest($request);
 
@@ -21,6 +23,20 @@ class AuthenticationDecorator
             return $validatedRequest;
         }
 
-        return call_user_func($this->callback, $validatedRequest);
+        $newRequest = $this->setTokenRequestParams($request, $validatedRequest);
+
+        return call_user_func($this->callback, $newRequest);
+    }
+
+    public function setTokenRequestParams(WP_REST_Request $request, array $params): WP_REST_Request
+    {
+        $request->set_param('session_id', $params['sessionId'] ?? null);
+        $request->set_param('national_identity_number', $params['id'] ?? null);
+        $request->set_param('name', $params['name'] ?? null);
+        $request->set_param('first_name', $params['firstName'] ?? null);
+        $request->set_param('surname', $params['lastName'] ?? null);
+        $request->set_param('source', isset($params['iss']) ? stripslashes($params['iss']) : null);
+        $request->set_param('aud', isset($params['aud']) ? stripslashes($params['aud']) : null);
+        return $request;
     }
 }

--- a/source/php/API/Auth/AuthenticationInterface.php
+++ b/source/php/API/Auth/AuthenticationInterface.php
@@ -9,7 +9,7 @@ interface AuthenticationInterface
     /**
      * Validate REST request with JWT
      * @param WP_REST_Request $request
-     * @return \WP_Error|\WP_REST_Request
+     * @return \WP_Error|array
      */
     public function validateRequest(WP_REST_Request $request);
 }

--- a/source/php/API/Auth/AuthenticationInterface.php
+++ b/source/php/API/Auth/AuthenticationInterface.php
@@ -9,7 +9,7 @@ interface AuthenticationInterface
     /**
      * Validate REST request with JWT
      * @param WP_REST_Request $request
-     * @return mixed Returns WP_REST_Request on success, or WP_Error on failure.
+     * @return \WP_Error|\WP_REST_Request
      */
-    public function validateRequest(WP_REST_Request $request): WP_REST_Request;
+    public function validateRequest(WP_REST_Request $request);
 }

--- a/source/php/API/Auth/AuthenticationInterface.php
+++ b/source/php/API/Auth/AuthenticationInterface.php
@@ -2,7 +2,6 @@
 
 namespace VolunteerManager\API\Auth;
 
-use WP_Error;
 use WP_REST_Request;
 
 interface AuthenticationInterface
@@ -10,7 +9,7 @@ interface AuthenticationInterface
     /**
      * Validate REST request with JWT
      * @param WP_REST_Request $request
-     * @return WP_REST_Request|WP_Error
+     * @return mixed Returns WP_REST_Request on success, or WP_Error on failure.
      */
-    public function validateRequest(WP_REST_Request $request): WP_REST_Request|WP_Error;
+    public function validateRequest(WP_REST_Request $request): WP_REST_Request;
 }

--- a/source/php/API/Auth/AuthenticationInterface.php
+++ b/source/php/API/Auth/AuthenticationInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace VolunteerManager\API\Auth;
+
+use WP_Error;
+use WP_REST_Request;
+
+interface AuthenticationInterface
+{
+    /**
+     * Validate REST request with JWT
+     * @param WP_REST_Request $request
+     * @return WP_REST_Request|WP_Error
+     */
+    public function validateRequest(WP_REST_Request $request): WP_REST_Request|WP_Error;
+}

--- a/source/php/API/Auth/JWTAuthentication.php
+++ b/source/php/API/Auth/JWTAuthentication.php
@@ -19,9 +19,9 @@ class JWTAuthentication implements AuthenticationInterface
     /**
      * Validate rest request with JWT
      * @param WP_REST_Request $request
-     * @return WP_REST_Request|WP_Error
+     * @return mixed Returns WP_REST_Request on success, or WP_Error on failure.
      */
-    public function validateRequest(WP_REST_Request $request): WP_REST_Request|WP_Error
+    public function validateRequest(WP_REST_Request $request): WP_REST_Request
     {
         $authHeader = $request->get_header('Authorization');
 

--- a/source/php/API/Auth/JWTAuthentication.php
+++ b/source/php/API/Auth/JWTAuthentication.php
@@ -19,7 +19,7 @@ class JWTAuthentication implements AuthenticationInterface
     /**
      * Validate rest request with JWT
      * @param WP_REST_Request $request
-     * @return \WP_Error|\WP_REST_Request
+     * @return \WP_Error|array
      */
     public function validateRequest(WP_REST_Request $request)
     {
@@ -59,8 +59,7 @@ class JWTAuthentication implements AuthenticationInterface
 
         try {
             $decodedToken = JWT::decode($token, new Key($this->secretKey, 'HS256'));
-            $request->decoded_token = (array)$decodedToken;
-            return $request;
+            return (array)$decodedToken;
         } catch (\Exception $e) {
             return new WP_Error(
                 'jwt_auth_invalid_token',

--- a/source/php/API/Auth/JWTAuthentication.php
+++ b/source/php/API/Auth/JWTAuthentication.php
@@ -19,9 +19,9 @@ class JWTAuthentication implements AuthenticationInterface
     /**
      * Validate rest request with JWT
      * @param WP_REST_Request $request
-     * @return mixed Returns WP_REST_Request on success, or WP_Error on failure.
+     * @return \WP_Error|\WP_REST_Request
      */
-    public function validateRequest(WP_REST_Request $request): WP_REST_Request
+    public function validateRequest(WP_REST_Request $request)
     {
         $authHeader = $request->get_header('Authorization');
 

--- a/source/php/API/Auth/JWTAuthentication.php
+++ b/source/php/API/Auth/JWTAuthentication.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace VolunteerManager\API\Auth;
+
+use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
+use WP_Error;
+use WP_REST_Request;
+
+class JWTAuthentication implements AuthenticationInterface
+{
+    private string $secretKey;
+
+    public function __construct($secretKey)
+    {
+        $this->secretKey = $secretKey;
+    }
+
+    /**
+     * Validate rest request with JWT
+     * @param WP_REST_Request $request
+     * @return WP_REST_Request|WP_Error
+     */
+    public function validateRequest(WP_REST_Request $request): WP_REST_Request|WP_Error
+    {
+        $authHeader = $request->get_header('Authorization');
+
+        if (!$authHeader) {
+            return new WP_Error(
+                'jwt_auth_no_auth_header',
+                'Authorization header not found.',
+                [
+                    'status' => 403,
+                ]
+            );
+        }
+
+        [$token] = sscanf($authHeader, 'Bearer %s');
+
+        if (!$token) {
+            return new WP_Error(
+                'jwt_auth_bad_auth_header',
+                'Authorization header malformed.',
+                [
+                    'status' => 403,
+                ]
+            );
+        }
+
+        if (!$this->secretKey) {
+            return new WP_Error(
+                'jwt_auth_bad_config',
+                'JWT key is not configured properly.',
+                [
+                    'status' => 403,
+                ]
+            );
+        }
+
+        try {
+            $decodedToken = JWT::decode($token, new Key($this->secretKey, 'HS256'));
+            $request->decoded_token = (array)$decodedToken;
+            return $request;
+        } catch (\Exception $e) {
+            return new WP_Error(
+                'jwt_auth_invalid_token',
+                'Invalid authentication token.',
+                [
+                    'status' => 403,
+                ]
+            );
+        }
+    }
+}


### PR DESCRIPTION
- Added class that validates a request with JWT header
- Added decorator that returns a validated callback  

It's not implemented yet it but it can be used like this:
Run "composer install" to install new dependencies.
Add new constant `define('JWT_SECRET_KEY', 'secret_key');`

```
$this->auth = new JWTAuthentication(JWT_SECRET_KEY);

add_action( 'rest_api_init', function ( $server ) {
	$server->register_route( 'foo', '/foo', array(
		'methods'  => 'GET',
		'callback' => new AuthenticationDecorator([$this, 'callback'], $this->auth)
	) );
} ); 
```