### PR TITLE
extract employer info from request params

### DIFF
--- a/source/php/API/Assignment/AssignmentCreator.php
+++ b/source/php/API/Assignment/AssignmentCreator.php
@@ -63,6 +63,9 @@ class AssignmentCreator extends ApiHandler
             'submitted_by_email',
             'submitted_by_first_name',
             'submitted_by_phone',
+            'employer_name',
+            'employer_contacts',
+            'employer_website'
         ];
 
         return $this->extractParamsFromRequest($request, $requestParams);


### PR DESCRIPTION
This PR introduces three new fields to the extractAssignmentDetailsFromRequest method in the AssignmentCreator.php file. These fields include:
- 'employer_name'
- 'employer_contacts'
- 'employer_website'


No deletions were made, ensuring existing functionality is preserved while expanding capabilities.

Tests have **not been** adjusted accordingly to accommodate these changes.